### PR TITLE
Update nginx conf to resolve URLs good

### DIFF
--- a/scripts/nginx_conf_part_2.conf
+++ b/scripts/nginx_conf_part_2.conf
@@ -48,7 +48,7 @@ server {
     index index.html index.htm;   
 
     location / {
-        try_files $uri $uri/ $uri.html =404;
+        try_files $uri $uri/ $uri.html /index.html =404;
     }
 
 }

--- a/scripts/nginx_conf_part_2.conf
+++ b/scripts/nginx_conf_part_2.conf
@@ -1,6 +1,6 @@
 server {
     listen 443;
-    server_name {{ hostname }};
+    server_name {{ hostname }} www.{{ hostname }};
     access_log /var/log/nginx/{{ appname }}-access.log;
     error_log /var/log/nginx/{{ appname }}-error.log;
     
@@ -55,7 +55,7 @@ server {
 
 server {
     listen 80;
-    server_name {{ hostname }};
+    server_name {{ hostname }} www.{{ hostname }};
     
     location ~ .well-known/acme-challenge {
        root /usr/share/nginx/html;

--- a/scripts/nginx_conf_part_2.conf
+++ b/scripts/nginx_conf_part_2.conf
@@ -48,7 +48,7 @@ server {
     index index.html index.htm;   
 
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ $uri.html =404;
     }
 
 }


### PR DESCRIPTION
The current config is optimized for single-page static sites. It also allows for users to input anything they want into a URL, i.e. "justicedivided.com/black-kids-deserve-it," and still be resolved to the site. This PR resolves URLs to their corresponding HTML files and returns a 404 if one is not found.  

It also does the www redirect for http & https. 