### PR TITLE
Use API Exceptions for more robust error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,12 +74,14 @@ def parsePost(post, branch):
 
     # End early if not permitted account
     if post['owner'] not in app_config.ACCOUNTS:
-        raise PayloadException('Account %s not permitted' % post['owner'])
+        raise PayloadException('Account {user} not permitted'.format(user=post['owner']),
+                               status_code=403)
 
     # End early if not permitted branch
 
     if post['branch'] != branch:
-        raise PayloadException('Branch %s not permitted' % post['branch'])
+        raise PayloadException('Branch {branch} not permitted'.format(branch=post['branch']),
+                               status_code=403)
 
     giturl = 'git@{server}:{owner}/{repo}.git'\
                  .format(server=app_config.GH_SERVER,

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import json
 import urllib.request
 import sys
 
-from flask import Flask, request, make_response, jsonify, abort
+from flask import Flask, request, make_response, jsonify
 from raven.contrib.flask import Sentry
 import app_config
 
@@ -19,17 +19,6 @@ sentry = Sentry(app, dsn=app_config.SENTRY_DSN)
 
 # expects GeoJSON object as a string
 # client will need to use JSON.stringify() or similar
-
-def json_abort(message, code):
-    abort(make_response(jsonify(error=message), code))
-    
-
-#class PayloadException(Exception):
-#    def __init__(self, message):
-#        
-#        super().__init__()
-#        
-#        self.message = message
 
 class AppError(Exception):
 

--- a/app.py
+++ b/app.py
@@ -130,9 +130,13 @@ def execute(site_type, branch_name):
 
     if script_args:
         
-        scripts = app_config.SCRIPTS[site_type]
-        
-        run_scripts.delay(scripts, script_args)
+        try:
+            scripts = app_config.SCRIPTS[site_type]
+        except KeyError:
+            raise ServerError("No script file defined for '{0}' in config.".format(site_type),
+                        status_code=501)
+        else:
+            run_scripts.delay(scripts, script_args)
 
     response = make_response(json.dumps(resp), 202)
     response.headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
Bad form on my part for combining two changes into one PR: 
1. Use [API exceptions](http://flask.pocoo.org/docs/1.0/patterns/apierrors/) for more robust error handling
2. abort on payload exceptions so that scripts are not run when payload exceptions occur 